### PR TITLE
Fixing Travis CI and GoReleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,17 +1,22 @@
 before:
   hooks:
   - go mod download
-
 builds:
--
-  goos:
-    - linux
-    - darwin
-  goarch:
-    - 386
-    - amd64
-    - arm
-    - arm64
-  goarm:
-    - 6
-    - 7
+- env:
+  - GO111MODULE=on
+  - CGO_ENABLED=0
+archives:
+  - id: kubemngr
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      386: i386
+      amd64: x86_64
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ env:
   - GO111MODULE=on
 install:
   - make setup
-  - make build
+script:
+  - make ci
 deploy:
   - provider: script
     skip_cleanup: true

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ default: build
 all: clean build_all install
 
 setup:
-	go mod tidy
+	go mod download
 
 go-mod-tidy:
 	@go mod tidy -v
@@ -32,7 +32,7 @@ go-mod-tidy:
 	@git diff-index --quiet HEAD
 .PHONY: go-mod-tidy
 
-ci: build go-mod-tidy
+ci: go-mod-tidy
 
 build:
 	go build

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,18 @@ default: build
 all: clean build_all install
 
 setup:
-	go mod download
+	go mod tidy
+
+go-mod-tidy:
+	@go mod tidy -v
+	@git diff HEAD
+	@git diff-index --quiet HEAD
+.PHONY: go-mod-tidy
+
+ci: build go-mod-tidy
 
 build:
-	go build ${LDFLAGS} -o ${BINARY}
+	go build
 
 build_all:
 	$(foreach GOOS, $(PLATFORMS),\

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ import (
 	"github.com/zee-ahmed/kubemngr/cmd"
 )
 
-var clientVersion = "0.0.1"
+var clientVersion = "0.1.0"
 
 func main() {
 


### PR DESCRIPTION
Setting `kubemngr` release to `v0.1.0`
Fixing Travis CI and GoReleaser to automate the release procedures